### PR TITLE
Standardize notification endpoints

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{connectorAppUpdateNotificationEndpointHost}}",
+        "host": "{{connectorEndpointHost}}",
         "path": "*"
       }
     },

--- a/node/clients/connector.ts
+++ b/node/clients/connector.ts
@@ -1,22 +1,21 @@
 import type { IOContext, InstanceOptions } from '@vtex/api'
-import { CONNECTOR_APP_UPDATE_NOTIFICATION_ENDPOINT } from '../constants/variables'
+import { CONNECTOR_ENDPOINT } from '../constants/variables'
 import { ExternalClient } from '@vtex/api'
 
 export default class ConnectorClient extends ExternalClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super(CONNECTOR_APP_UPDATE_NOTIFICATION_ENDPOINT,
+    super(CONNECTOR_ENDPOINT,
       context, options
     )
   }
 
-  public async notifyConnectorAppUpdate(config: Configuration)
-  {
+  public async notifyConnectorAppUpdate(config: Configuration) {
     var expression = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
     var regex = new RegExp(expression);
 
-    if (CONNECTOR_APP_UPDATE_NOTIFICATION_ENDPOINT.match(regex)) {
+    if (CONNECTOR_ENDPOINT.match(regex)) {
       config.accountName = this.context.account,
-      this.http.post("", config)
+        this.http.post("store-config/notification", config)
     }
 
   }

--- a/node/clients/connector.ts
+++ b/node/clients/connector.ts
@@ -10,13 +10,12 @@ export default class ConnectorClient extends ExternalClient {
   }
 
   public async notifyConnectorAppUpdate(config: Configuration) {
-    var expression = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
-    var regex = new RegExp(expression);
+    var expression = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi
+    var regex = new RegExp(expression)
 
     if (CONNECTOR_ENDPOINT.match(regex)) {
-      config.accountName = this.context.account,
-        this.http.post("store-config/notification", config)
+      config.accountName = this.context.account
+      this.http.post("store-config/notification", config)
     }
-
   }
 }

--- a/node/clients/core.ts
+++ b/node/clients/core.ts
@@ -9,6 +9,8 @@ import {
   VBASE_CONFIG_BASE_PATH,
 } from '../constants/variables'
 
+const AFILLIATE_CATALOG_NOTIFICATION_PATH = "/catalog/notification";
+
 export default class CoreClient extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
@@ -37,7 +39,7 @@ export default class CoreClient extends JanusClient {
       id: config.affiliateId,
       followUpEmail: config.email,
       salesChannelId: config.salesChannel,
-      searchEndpoint: CONNECTOR_ENDPOINT,
+      searchEndpoint: CONNECTOR_ENDPOINT.replace(/\/+$/, '').concat(AFILLIATE_CATALOG_NOTIFICATION_PATH),
     })
 
   public getConfigFromVBase = (vbase: VBase) =>

--- a/node/constants/variables.ts
+++ b/node/constants/variables.ts
@@ -4,6 +4,3 @@ export const VBASE_BUCKET = '{{appName}}'
 export const VBASE_CONFIG_BASE_PATH = 'storeConfig'
 export const APP_VENDOR = '{{appVendor}}'
 export const FEED_ID = '{{feedId}}'
-export const CONNECTOR_ORDER_PROCESSING_NOTIFICATION_ENDPOINT =
-  '{{orderProcessingNotificationEndpoint}}'
-export const CONNECTOR_APP_UPDATE_NOTIFICATION_ENDPOINT = '{{connectorAppUpdateNotificationEndpoint}}'

--- a/node/routes/getConnectorConfig.ts
+++ b/node/routes/getConnectorConfig.ts
@@ -2,7 +2,7 @@ import httpStatus from 'http-status-codes'
 
 import {
   APP_VENDOR,
-  CONNECTOR_ORDER_PROCESSING_NOTIFICATION_ENDPOINT,
+  CONNECTOR_ENDPOINT,
 } from '../constants/variables'
 
 const headersExist = (headers: any) => headers?.appkey && headers?.apptoken
@@ -34,8 +34,8 @@ export const getConnectorConfig = async (ctx: Context) => {
     })
   } else {
     const config: ConnectorConfiguration = {
-      orderProcessingNotificationEndpoint:
-        CONNECTOR_ORDER_PROCESSING_NOTIFICATION_ENDPOINT,
+      connectorEndpoint:
+        CONNECTOR_ENDPOINT,
     }
 
     if (!config) {

--- a/node/typings/connectorConfiguration.d.ts
+++ b/node/typings/connectorConfiguration.d.ts
@@ -1,3 +1,3 @@
 interface ConnectorConfiguration {
-  orderProcessingNotificationEndpoint: string
+  connectorEndpoint: string
 }

--- a/react/areas/ConfigArea/DefaultConfigs/endpoint.tsx
+++ b/react/areas/ConfigArea/DefaultConfigs/endpoint.tsx
@@ -5,6 +5,7 @@ import InputComponent from '../../../components/InputComponent'
 import type { DefaultProps } from '../../../typings/props'
 
 const CONNECTOR_ENDPOINT = '{{connectorEndpoint}}'
+const AFILLIATE_CATALOG_NOTIFICATION_PATH = "/catalog/notification";
 
 const SearchEndpoint: React.FC<DefaultProps> = ({ intl, config }) => {
   return (
@@ -17,7 +18,7 @@ const SearchEndpoint: React.FC<DefaultProps> = ({ intl, config }) => {
           })}
           canEdit={false}
           type="text"
-          initValue={CONNECTOR_ENDPOINT}
+          initValue={CONNECTOR_ENDPOINT.replace(/\/+$/, '').concat(AFILLIATE_CATALOG_NOTIFICATION_PATH)}
         />
       </Box>
       <Anchor


### PR DESCRIPTION
<!--- Add the link to the Jira issue this PR relates to, if it exists. -->
[**Jira Issue**](https://vtex-dev.atlassian.net/browse/CORE-385)

#### What is the purpose of this pull request?

- Standardize template to use just the Connector's base endpoint and fixed/predetermined paths for notifications:
  - `/catalog/notification` for Broadcaster SKUs updates
  - `/store-config/notification` for seller's config updates

#### What problem is this solving?

- Now the partner only needs to fill one endpoint config instead of three, and we have the app template following the same pattern as Channel Order API.

#### Types of changes

- [x] Refactor (doesn't change the behaviour but improves code readability)
- [ ] Infrastructure change (deployment settings and such)
- [ ] Security issue (non-breaking change that fixes a security issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which will be updated accordingly.

#trivial