### PR TITLE
Turning AffiliateId editable

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,7 @@
   "admin/app.input.requiredMessage": "Required field",
   "admin/app.cultureInfo.title": "Country",
   "admin/app.error.affiliate.registerFail": "Something went wrong when registering the affiliate.",
-  "admin/app.error.affiliate.alreadyRegistered": "The selected affiliate id already exist. Change the affiliate id or delete the one registered to continue.",
+  "admin/app.error.affiliate.alreadyRegistered": "The selected affiliate id already exist. Change the affiliate id or delete the one registered and try again.",
   "admin/app.error.affiliate.invalidFormat": "Affiliate with invalid format. It needs to be 3 consonants.",
   "admin/app.error.salesChannel.invalidFormat": "Sales channel with invalid format. It needs to be an integer number.",
   "admin/app.mapper.title": "Category mapping",

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,7 @@
   "admin/app.input.requiredMessage": "Required field",
   "admin/app.cultureInfo.title": "Country",
   "admin/app.error.affiliate.registerFail": "Something went wrong when registering the affiliate.",
-  "admin/app.error.affiliate.alreadyRegistered": "The selected affiliate id already exist. Change the affiliate id or delete the one registered and try again.",
+  "admin/app.error.affiliate.alreadyRegistered": "The selected affiliate id already exists. Change the affiliate id or delete the one registered and try again.",
   "admin/app.error.affiliate.invalidFormat": "Affiliate with invalid format. It needs to be 3 consonants.",
   "admin/app.error.salesChannel.invalidFormat": "Sales channel with invalid format. It needs to be an integer number.",
   "admin/app.mapper.title": "Category mapping",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,6 +4,7 @@
   "admin/app.config.title": "Settings",
   "admin/app.saveConfig.success": "Configuration successfully saved.",
   "admin/app.affiliateId.title": "Affiliate ID",
+  "admin/app.affiliateId.tooltip": "ID (3 consonants) that'll represent your connection with this marketplace. Need to be unique in your account.",
   "admin/app.salesChannel.title": "Sales Channel",
   "admin/app.allow-franchise.title": "Allow Franchise Accounts",
   "admin/app.salesChannel.tooltip": "Catalog that will be sent to the marketplace.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,7 @@
   "admin/app.input.requiredMessage": "Required field",
   "admin/app.cultureInfo.title": "Country",
   "admin/app.error.affiliate.registerFail": "Something went wrong when registering the affiliate.",
+  "admin/app.error.affiliate.alreadyRegistered": "The selected affiliate id already exist. Change the affiliate id or delete the one registered to continue.",
   "admin/app.error.affiliate.invalidFormat": "Affiliate with invalid format. It needs to be 3 consonants.",
   "admin/app.error.salesChannel.invalidFormat": "Sales channel with invalid format. It needs to be an integer number.",
   "admin/app.mapper.title": "Category mapping",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,7 +4,7 @@
   "admin/app.config.title": "Settings",
   "admin/app.saveConfig.success": "Configuration successfully saved.",
   "admin/app.affiliateId.title": "Affiliate ID",
-  "admin/app.affiliateId.tooltip": "ID (3 consonants) that'll represent your connection with this marketplace. Need to be unique in your account.",
+  "admin/app.affiliateId.tooltip": "ID (3 consonants) that'll represent your connection with this marketplace. Needs to be unique in your account.",
   "admin/app.salesChannel.title": "Sales Channel",
   "admin/app.allow-franchise.title": "Allow Franchise Accounts",
   "admin/app.salesChannel.tooltip": "Catalog that will be sent to the marketplace.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,7 +17,7 @@
   "admin/app.input.requiredMessage": "Campo obligatorio",
   "admin/app.cultureInfo.title": "País",
   "admin/app.error.affiliate.registerFail": "Se produjo un error al registrar el afiliado.",
-  "admin/app.error.affiliate.alreadyRegistered": "El ID de afiliado seleccionado ya existe. Cambie la identificación de afiliado o elimine la registrada para continuar.",
+  "admin/app.error.affiliate.alreadyRegistered": "El ID de afiliado seleccionado ya existe. Cambie la identificación de afiliado o elimine la registrada e intente nuevamente.",
   "admin/app.error.affiliate.invalidFormat": "Afiliado con formato inválido. Debe constar de 3 consonantes.",
   "admin/app.error.salesChannel.invalidFormat": "Canal de ventas con formato inválido. Debe ser un número entero.",
   "admin/app.mapper.title": "Mapeo de categorías",

--- a/messages/es.json
+++ b/messages/es.json
@@ -16,6 +16,7 @@
   "admin/app.input.requiredMessage": "Campo obligatorio",
   "admin/app.cultureInfo.title": "País",
   "admin/app.error.affiliate.registerFail": "Se produjo un error al registrar el afiliado.",
+  "admin/app.error.affiliate.alreadyRegistered": "El ID de afiliado seleccionado ya existe. Cambie la identificación de afiliado o elimine la registrada para continuar.",
   "admin/app.error.affiliate.invalidFormat": "Afiliado con formato inválido. Debe constar de 3 consonantes.",
   "admin/app.error.salesChannel.invalidFormat": "Canal de ventas con formato inválido. Debe ser un número entero.",
   "admin/app.mapper.title": "Mapeo de categorías",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,6 +4,7 @@
   "admin/app.config.title": "Configuración",
   "admin/app.saveConfig.success": "La configuración se guardó con éxito.",
   "admin/app.affiliateId.title": "ID del afiliado",
+  "admin/app.affiliateId.tooltip": "ID (3 consonantes) que representará su conexión con este mercado. Debe ser único en su cuenta.",
   "admin/app.salesChannel.title": "Canal de ventas",
   "admin/app.allow-franchise.title": "Permitir Cuentas Franquicia",
   "admin/app.salesChannel.tooltip": "Catálogo que se enviará al marketplace.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -17,7 +17,7 @@
   "admin/app.input.requiredMessage": "Campo obrigatório",
   "admin/app.cultureInfo.title": "País",
   "admin/app.error.affiliate.registerFail": "Ocorreu um erro ao registrar o afiliado.",
-  "admin/app.error.affiliate.alreadyRegistered": "O ID de afiliado selecionado já existe. Troque o ID do afiliado ou delete o já registrado para continuar.",
+  "admin/app.error.affiliate.alreadyRegistered": "O ID de afiliado selecionado já existe. Troque o ID do afiliado ou delete o já registrado e tente novamente.",
   "admin/app.error.affiliate.invalidFormat": "Afiliado com formato inválido. Deve consistir em 3 consoantes.",
   "admin/app.error.salesChannel.invalidFormat": "Canal de vendas com formato inválido. Deve ser um número inteiro.",
   "admin/app.mapper.title": "Mapeamento de categorias",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -16,6 +16,7 @@
   "admin/app.input.requiredMessage": "Campo obrigatório",
   "admin/app.cultureInfo.title": "País",
   "admin/app.error.affiliate.registerFail": "Ocorreu um erro ao registrar o afiliado.",
+  "admin/app.error.affiliate.alreadyRegistered": "O ID de afiliado selecionado já existe. Troque o ID do afiliado ou delete o já registrado para continuar.",
   "admin/app.error.affiliate.invalidFormat": "Afiliado com formato inválido. Deve consistir em 3 consoantes.",
   "admin/app.error.salesChannel.invalidFormat": "Canal de vendas com formato inválido. Deve ser um número inteiro.",
   "admin/app.mapper.title": "Mapeamento de categorias",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4,6 +4,7 @@
   "admin/app.config.title": "Configurações",
   "admin/app.saveConfig.success": "Configuração salva com êxito.",
   "admin/app.affiliateId.title": "ID do afiliado",
+  "admin/app.affiliateId.tooltip": "ID (3 consoantes) que vai representar sua conexão com este marketplace. Precisa ser único na sua conta.",
   "admin/app.salesChannel.title": "Canal de Vendas",
   "admin/app.allow-franchise.title": "Permitir Contas Franquia",
   "admin/app.salesChannel.tooltip": "Catálogo que será enviado para o marketplace.",

--- a/node/clients/affiliate.ts
+++ b/node/clients/affiliate.ts
@@ -1,0 +1,57 @@
+import type { IOContext, InstanceOptions } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+import { NOT_FOUND } from '../constants/statusCode';
+
+import {
+  CONNECTOR_ENDPOINT,
+  CONNECTOR_NAME,
+} from '../constants/variables'
+
+const AFILLIATE_CATALOG_NOTIFICATION_PATH = "/catalog/notification";
+
+export default class AffiliateClient extends JanusClient {
+  private routes = {
+    getAffiliateById: (affiliateId: string) => `/api/fulfillment/pvt/affiliates/${affiliateId}`,
+    registerAffiliate: (affiliateId: string) => `/api/fulfillment/pvt/affiliates/${affiliateId}`
+  }
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        VtexIdclientAutCookie:
+          context.adminUserAuthToken ?? context.authToken ?? '',
+      },
+    })
+  }
+
+  public isAffiliateAlreadyRegistered = (affiliateId: string) =>
+    this.http
+      .getRaw(this.routes.getAffiliateById(affiliateId), {
+        params: {
+          an: this.context.account
+        }
+      }).then(getAffiliateResponse => {
+        return getAffiliateResponse.status.toString().startsWith("2")
+      }).catch(err => {
+        return !(err?.response?.status === NOT_FOUND)
+      })
+
+  public registerAffiliate = async (config: Configuration) =>
+    this.http
+        .put(this.routes.registerAffiliate(config.affiliateId),
+        {
+            id: config.affiliateId,
+            name: `${CONNECTOR_NAME}-${config.affiliateId}`,
+            followUpEmail: config.email,
+            salesChannel: config.salesChannel,
+            searchURIEndpoint: CONNECTOR_ENDPOINT.replace(/\/+$/, '').concat(AFILLIATE_CATALOG_NOTIFICATION_PATH),
+            SearchURIEndpointVersion: "1.x.x",
+            SearchURIEndpointAvailableVersions: ["1.x.x"]
+        },
+        {
+            params: {
+                an: this.context.account
+            }
+        })
+}

--- a/node/clients/core.ts
+++ b/node/clients/core.ts
@@ -9,6 +9,10 @@ import {
   VBASE_CONFIG_BASE_PATH,
 } from '../constants/variables'
 
+import {
+  NOT_FOUND,
+} from '../constants/statusCode'
+
 const AFILLIATE_CATALOG_NOTIFICATION_PATH = "/catalog/notification";
 
 export default class CoreClient extends JanusClient {
@@ -20,6 +24,17 @@ export default class CoreClient extends JanusClient {
           context.adminUserAuthToken ?? context.authToken ?? '',
       },
     })
+  }
+
+  public isAffiliateAlreadyRegisted = (affiliateId) => {
+    const getAffiliateResponse = this.https
+      .get(`api/fulfillment/affiliates/${affiliateId}`, {
+        params: {
+          an: this.context.account,
+        }
+      })
+
+    return !(getAffiliateResponse.status === NOT_FOUND)
   }
 
   public getSalesChannelsAsync = () =>

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,5 +1,5 @@
 import { IOClients } from '@vtex/api'
-import { Affiliate } from '@vtex/clients'
+import AffiliateClient from './affiliate'
 import ConnectorClient from './connector'
 
 import CoreClient from './core'
@@ -9,7 +9,7 @@ import VtexIDClient from './vtexId'
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
   public get affiliate() {
-    return this.getOrSet('affiliate', Affiliate)
+    return this.getOrSet('affiliate', AffiliateClient)
   }
 
   public get vtexID() {

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -27,14 +27,13 @@ export const saveConfiguration = async (
 
   const { affiliateId, salesChannel } = config
 
-  await ctx.clients.sentOffers
-    .createFeed({ affiliateId, salesChannel, id: FEED_ID })
-    .then(async () => {
-      await ctx.clients.core.registerAffiliate(config, ctx).catch((__) => {
-        throw new UserInputError('admin/app.error.affiliate.registerFail')
-      })
+  await ctx.clients.core.registerAffiliate(config, ctx)
+    .catch((_) => {
+      throw new UserInputError('admin/app.error.affiliate.registerFail')
     })
-    .catch((___) => {
+
+  await ctx.clients.sentOffers.createFeed({ affiliateId, salesChannel, id: FEED_ID })
+    .catch((_) => {
       throw new UserInputError('admin/app.sentoffers.error')
     })
 }

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -24,12 +24,10 @@ export const saveConfiguration = async (
 
   const currentStoreConfig = await ctx.clients.core.getConfigFromVBase(ctx.clients.vbase)
 
-  if(currentStoreConfig != null){
-    if(currentStoreConfig.affiliateId != affiliateId) {
-      const res = await ctx.clients.affiliate.isAffiliateAlreadyRegistered(affiliateId)
-      if(res){
-        throw new UserInputError('admin/app.error.affiliate.alreadyRegistered')  
-      }
+  if(currentStoreConfig === null || currentStoreConfig.affiliateId !== affiliateId){
+    const res = await ctx.clients.affiliate.isAffiliateAlreadyRegistered(affiliateId)
+    if(res){
+      throw new UserInputError('admin/app.error.affiliate.alreadyRegistered')  
     }
   }
 

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -1,4 +1,5 @@
 import { UserInputError } from '@vtex/api'
+import { FEED_ID } from '../constants/variables'
 
 const validateConfig = (config: Configuration) => {
   const regexOnlyNumbers = /^[0-9]+$/
@@ -37,4 +38,10 @@ export const saveConfiguration = async (
     })
 
   await ctx.clients.core.saveConfigInVBase(config, ctx.clients.vbase)
+  await ctx.clients.connector.notifyConnectorAppUpdate(config)
+  
+  await ctx.clients.sentOffers.createFeed({ affiliateId: config.affiliateId, salesChannel: config.salesChannel, id: FEED_ID })
+    .catch(_ => {
+      throw new UserInputError('admin/app.sentOffers.error')
+    })
 }

--- a/react/areas/ConfigArea/DefaultConfigs/affiliate.tsx
+++ b/react/areas/ConfigArea/DefaultConfigs/affiliate.tsx
@@ -8,7 +8,7 @@ const Affiliate: React.FC<DefaultProps> = ({ intl, config }) => {
     <InputComponent
       id="affiliateId"
       label={intl.formatMessage({ id: 'admin/app.affiliateId.title' })}
-      canEdit={false}
+      canEdit={true}
       initValue={config.affiliateId}
       type="text"
     />

--- a/react/areas/ConfigArea/DefaultConfigs/affiliate.tsx
+++ b/react/areas/ConfigArea/DefaultConfigs/affiliate.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import InputComponent from '../../../components/InputComponent'
 import type { DefaultProps } from '../../../typings/props'
 
-const Affiliate: React.FC<DefaultProps> = ({ intl, config }) => {
+export interface AffiliateProps extends DefaultProps {
+  setConfig: React.Dispatch<React.SetStateAction<Configuration>>
+}
+
+const Affiliate: React.FC<AffiliateProps> = ({ intl, config, setConfig }) => {
   return (
     <InputComponent
       id="affiliateId"
@@ -11,6 +15,13 @@ const Affiliate: React.FC<DefaultProps> = ({ intl, config }) => {
       canEdit={true}
       initValue={config.affiliateId}
       type="text"
+      required
+      tooltip={intl.formatMessage({ id: 'admin/app.affiliateId.tooltip' })}
+      onChange={(value) => {
+        if (value !== undefined) {
+          setConfig((oldConfig) => ({ ...oldConfig, affiliateId: value }))
+        }
+      }}
     />
   )
 }

--- a/react/areas/ConfigArea/DefaultConfigs/index.tsx
+++ b/react/areas/ConfigArea/DefaultConfigs/index.tsx
@@ -19,7 +19,7 @@ const DefaultConfigsArea: React.FC<DefaultConfigsProps> = ({
 }) => {
   return (
     <div>
-      <Affiliate config={config} intl={intl} />
+      <Affiliate config={config} intl={intl} setConfig={setConfig} />
       <SearchEndpoint config={config} intl={intl} />
       <SalesChannel intl={intl} config={config} setConfig={setConfig} sc={sc} />
       <Email intl={intl} config={config} setConfig={setConfig} />

--- a/react/areas/ConfigArea/index.tsx
+++ b/react/areas/ConfigArea/index.tsx
@@ -80,7 +80,11 @@ const ConfigArea: FC = () => {
                 id: 'admin/app.error.affiliate.invalidFormat',
               })
               break
-
+            case 'admin/app.error.affiliate.alreadyRegistered':
+              message = intl.formatMessage({
+                id: 'admin/app.error.affiliate.alreadyRegistered',
+              })
+              break
             default:
               message = ''
               break

--- a/react/areas/ConfigArea/index.tsx
+++ b/react/areas/ConfigArea/index.tsx
@@ -13,7 +13,7 @@ import CustomConfigs from './CustomConfigs'
 
 const defaultConfigs: Configuration = {
   active: false,
-  affiliateId: '{{affiliateId}}',
+  affiliateId: '',
   salesChannel: '',
   email: 'email@email.com',
   allowFranchiseAccounts: false


### PR DESCRIPTION
- Changing AffiliateId component from a non-editable input (configured by the partner) to an editable input, where the seller can choose the ID
- Validating if the seller has any other AffiliateId with same ID as the one that is being configured
- Changing Affiliate name (`name` property), concatenating CONNECTOR_NAME placeholder with AffiliateId, solving the problem of seller changing their current AffiliateId to another and getting an error because of the name (fulfillment returns an error if two affiliates have the same property `name`)