### PR TITLE
Feat/send connection status to channel manager using Courier

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,9 @@
     },
     {
       "name": "WorkflowAction"
+    },
+    {
+      "name": "colossus-fire-event"
     }
   ],
   "credentialType": "absolute",

--- a/node/clients/channelManager.ts
+++ b/node/clients/channelManager.ts
@@ -1,0 +1,28 @@
+import { JanusClient } from '@vtex/api'
+import type { IOContext, InstanceOptions } from '@vtex/api'
+
+export interface ConnectionEventMessage {
+  isActive: boolean
+  affiliateId: string
+}
+
+export default class ChannelManager extends JanusClient {
+  private baseUrl: string
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        VtexIdclientAutCookie:
+          context.adminUserAuthToken ?? context.authToken ?? '',
+      },
+    })
+    this.baseUrl = `/api/channel-manager`
+  }
+
+  public upsertMerchantConnection = (
+    data: ConnectionEventMessage,
+    connectorId: string
+  ) =>
+    this.http.post(`${this.baseUrl}/connector/${connectorId}/connection`, data)
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,11 +1,12 @@
 import { IOClients } from '@vtex/api'
+
 import AffiliateClient from './affiliate'
 import CatalogClient from './catalog'
 import ConnectorClient from './connector'
-
 import ConfigurationClient from './configuration'
 import SentOffers from './sentOffers'
 import VtexIDClient from './vtexId'
+import ChannelManager from './channelManager'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
@@ -31,5 +32,9 @@ export class Clients extends IOClients {
 
   public get catalog() {
     return this.getOrSet('catalog', CatalogClient)
+  }
+
+  public get channelManager() {
+    return this.getOrSet('channelManager', ChannelManager)
   }
 }

--- a/node/constants/variables.ts
+++ b/node/constants/variables.ts
@@ -1,8 +1,13 @@
 export const CONNECTOR_NAME = '{{appTitle}}'
 export const CONNECTOR_ENDPOINT = '{{connectorEndpoint}}'
 export const VBASE_BUCKET = '{{appName}}'
+export const APP_NAME = '{{appName}}'
 export const VBASE_CONFIG_BASE_PATH = 'storeConfig'
 export const APP_VENDOR = '{{appVendor}}'
 export const FEED_ID = '{{feedId}}'
 export const VTEX_APP_KEY_HEADER = 'x-vtex-api-appkey'
 export const VTEX_APP_TOKEN_HEADER = 'x-vtex-api-apptoken'
+export const CONNECTOR_ID = '{{connectorId}}'
+export const EMPTY_STRING = ''
+export const UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY =
+  '{{appVendor}}.{{appName}}-update-channel-manager-connection-status'

--- a/node/constants/variables.ts
+++ b/node/constants/variables.ts
@@ -1,7 +1,6 @@
 export const CONNECTOR_NAME = '{{appTitle}}'
 export const CONNECTOR_ENDPOINT = '{{connectorEndpoint}}'
 export const VBASE_BUCKET = '{{appName}}'
-export const APP_NAME = '{{appName}}'
 export const VBASE_CONFIG_BASE_PATH = 'storeConfig'
 export const APP_VENDOR = '{{appVendor}}'
 export const FEED_ID = '{{feedId}}'

--- a/node/events/index.ts
+++ b/node/events/index.ts
@@ -1,6 +1,7 @@
 import type { EventContext } from '@vtex/api'
 
 import type { Clients } from '../clients'
+import type { ConnectionEventMessage } from '../clients/channelManager'
 
 export type IOEventContext = EventContext<Clients>
 
@@ -16,5 +17,13 @@ interface UpdateConnectionStatus extends IOEventContext {
 }
 
 export const updateConnectionStatus = (ctx: UpdateConnectionStatus) => {
-  return ctx.body.affiliateId
+  const data: ConnectionEventMessage = {
+    affiliateId: ctx.body.affiliateId,
+    isActive: ctx.body.isActive,
+  }
+
+  ctx.clients.channelManager.upsertMerchantConnection(
+    data,
+    ctx.body.connectorId
+  )
 }

--- a/node/events/index.ts
+++ b/node/events/index.ts
@@ -1,0 +1,20 @@
+import type { EventContext } from '@vtex/api'
+
+import type { Clients } from '../clients'
+
+export type IOEventContext = EventContext<Clients>
+
+export interface ConnectionStatusInformation {
+  isActive: boolean
+  connectorId: string
+  affiliateId: string
+  merchantAccount: string
+}
+
+interface UpdateConnectionStatus extends IOEventContext {
+  body: ConnectionStatusInformation
+}
+
+export const updateConnectionStatus = (ctx: UpdateConnectionStatus) => {
+  return ctx.body.affiliateId
+}

--- a/node/events/index.ts
+++ b/node/events/index.ts
@@ -16,7 +16,7 @@ interface UpdateConnectionStatus extends IOEventContext {
   body: ConnectionStatusInformation
 }
 
-export const updateConnectionStatus = (ctx: UpdateConnectionStatus) => {
+export function updateConnectionStatus(ctx: UpdateConnectionStatus) {
   const data: ConnectionEventMessage = {
     affiliateId: ctx.body.affiliateId,
     isActive: ctx.body.isActive,

--- a/node/index.ts
+++ b/node/index.ts
@@ -3,6 +3,7 @@ import { LRUCache, Service } from '@vtex/api'
 import { mapObjIndexed } from 'ramda'
 
 import { Clients } from './clients'
+import { updateConnectionStatus } from './events'
 import { mutations, queries } from './resolvers'
 import { getConfig } from './routes/getConfig'
 import { getConnectorConfig } from './routes/getConnectorConfig'
@@ -57,4 +58,7 @@ export default new Service({
     getConfig,
     getConnectorConfig,
   }),
+  events: {
+    updateConnectionStatus,
+  },
 })

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -60,7 +60,7 @@ export const saveConfiguration = async (
 
   ctx.clients.events.sendEvent(
     EMPTY_STRING,
-    `${CONNECTOR_NAME}-${APP_NAME}-${UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY}`,
+    `${UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY}`,
     eventBody
   )
 

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -1,9 +1,7 @@
 import { UserInputError } from '@vtex/api'
 
 import {
-  APP_NAME,
   CONNECTOR_ID,
-  CONNECTOR_NAME,
   EMPTY_STRING,
   FEED_ID,
   UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY,

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -55,7 +55,7 @@ export const saveConfiguration = async (
     isActive: config.active,
     connectorId: CONNECTOR_ID,
     affiliateId: config.affiliateId,
-    merchantAccount: config.accountName,
+    merchantAccount: ctx.vtex.account,
   }
 
   ctx.clients.events.sendEvent(

--- a/node/resolvers/saveConfig.ts
+++ b/node/resolvers/saveConfig.ts
@@ -1,5 +1,14 @@
 import { UserInputError } from '@vtex/api'
-import { FEED_ID } from '../constants/variables'
+
+import {
+  APP_NAME,
+  CONNECTOR_ID,
+  CONNECTOR_NAME,
+  EMPTY_STRING,
+  FEED_ID,
+  UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY,
+} from '../constants/variables'
+import type { ConnectionStatusInformation } from '../events'
 
 const validateConfig = (config: Configuration) => {
   const regexOnlyNumbers = /^[0-9]+$/
@@ -22,24 +31,49 @@ export const saveConfiguration = async (
   validateConfig(config)
 
   const { affiliateId } = config
-  const currentStoreConfig = await ctx.clients.configuration.getConfigFromVBase(ctx.clients.vbase)
-  if (currentStoreConfig === null || currentStoreConfig.affiliateId !== affiliateId) {
-    const res = await ctx.clients.affiliate.isAffiliateAlreadyRegistered(affiliateId)
+  const currentStoreConfig = await ctx.clients.configuration.getConfigFromVBase(
+    ctx.clients.vbase
+  )
+
+  if (
+    currentStoreConfig === null ||
+    currentStoreConfig.affiliateId !== affiliateId
+  ) {
+    const res = await ctx.clients.affiliate.isAffiliateAlreadyRegistered(
+      affiliateId
+    )
+
     if (res) {
       throw new UserInputError('admin/app.error.affiliate.alreadyRegistered')
     }
   }
 
-  await ctx.clients.affiliate.registerAffiliate(config)
-    .catch(_ => {
-      throw new UserInputError('admin/app.error.affiliate.registerFail')
-    })
+  await ctx.clients.affiliate.registerAffiliate(config).catch((__) => {
+    throw new UserInputError('admin/app.error.affiliate.registerFail')
+  })
+  const eventBody: ConnectionStatusInformation = {
+    isActive: config.active,
+    connectorId: CONNECTOR_ID,
+    affiliateId: config.affiliateId,
+    merchantAccount: config.accountName,
+  }
+
+  ctx.clients.events.sendEvent(
+    EMPTY_STRING,
+    `${CONNECTOR_NAME}-${APP_NAME}-${UPDATE_CHANNEL_MANAGER_CONNECTION_STATUS_KEY}`,
+    eventBody
+  )
 
   await ctx.clients.configuration.saveConfigInVBase(config, ctx.clients.vbase)
   await ctx.clients.connector.notifyConnectorAppUpdate(config)
 
-  await ctx.clients.sentOffers.createFeed({ affiliateId: config.affiliateId, salesChannel: config.salesChannel, id: FEED_ID })
-    .catch(_ => {
+  await ctx.clients.sentOffers
+    .createFeed({
+      affiliateId: config.affiliateId,
+      salesChannel: config.salesChannel,
+      id: FEED_ID,
+    })
+    .catch((___) => {
       throw new UserInputError('admin/app.sentOffers.error')
     })
 }

--- a/node/service.json
+++ b/node/service.json
@@ -15,5 +15,13 @@
       "path": "/_v/{{appVendor}}/{{appName}}/connectorConfig",
       "public": true
     }
+  },
+  "events": {
+    "updateConnectionStatus": {
+      "sender": "{{appVendor}}.{{appName}}",
+      "keys": [
+        "{{appVendor}}.{{appName}}-update-channel-manager-connection-status"
+      ]
+    }
   }
 }


### PR DESCRIPTION
[workspace](https://talita--taistore.myvtex.com/admin/taistore/taistore)

set affiliate ID to MLC or another one that already exists.

Check connector `isConnectionActive` status (true/false), should match store config status

```
curl --location --request GET 'https://portal.vtexcommercestable.com.br/api/channel-manager/connector/291?an=taistore' \
--header 'X-VTEX-API-AppToken: {{appToken}}' \
--header 'X-VTEX-API-AppKey: {{appKey}}' 
```

Uses courier to make it asynchronous.